### PR TITLE
Fixed failing test because of import

### DIFF
--- a/src/vimseo/problems/mock/__init__.py
+++ b/src/vimseo/problems/mock/__init__.py
@@ -14,3 +14,5 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from __future__ import annotations
+
+X1_DEFAULT_VALUE = 0.1

--- a/src/vimseo/problems/mock/mock_pre_run_post/mock_components_lc1.py
+++ b/src/vimseo/problems/mock/mock_pre_run_post/mock_components_lc1.py
@@ -21,8 +21,7 @@ from numpy import atleast_1d
 from vimseo.core.components.post.post_processor import PostProcessor
 from vimseo.core.components.pre.pre_processor import PreProcessor
 from vimseo.core.components.run.run_processor import RunProcessor
-
-X1_DEFAULT_VALUE = 0.1
+from vimseo.problems.mock import X1_DEFAULT_VALUE
 
 
 class MockPre(PreProcessor):

--- a/src/vimseo/problems/mock/mock_pre_run_post/mock_components_lc2.py
+++ b/src/vimseo/problems/mock/mock_pre_run_post/mock_components_lc2.py
@@ -18,10 +18,9 @@ from __future__ import annotations
 from numpy import array
 from numpy import atleast_1d
 
+from vimseo.problems.mock import X1_DEFAULT_VALUE
 from vimseo.problems.mock.mock_pre_run_post.mock_components_lc1 import MockPost
 from vimseo.problems.mock.mock_pre_run_post.mock_components_lc1 import MockPre
-
-X1_DEFAULT_VALUE = 0.1
 
 
 class MockPre_LC2(MockPre):

--- a/src/vimseo/problems/mock/mock_reference_data/mock_main_reference_functions.py
+++ b/src/vimseo/problems/mock/mock_reference_data/mock_main_reference_functions.py
@@ -23,8 +23,7 @@ from vimseo.core.components.pre.pre_processor import PreProcessor
 from vimseo.core.components.run.run_processor import RunProcessor
 from vimseo.core.pre_run_post_model import PreRunPostModel
 from vimseo.material_lib import MATERIAL_LIB_DIR
-
-X1_DEFAULT_VALUE = 0.1
+from vimseo.problems.mock import X1_DEFAULT_VALUE
 
 
 def mock_model_lc1_overall_function(x1):

--- a/tests/tools/test_space_builders.py
+++ b/tests/tools/test_space_builders.py
@@ -27,7 +27,7 @@ from numpy import sign
 
 import vimseo.tools as tools
 from vimseo.api import create_model
-from vimseo.problems.mock.mock_pre_run_post.mock_main import X1_DEFAULT_VALUE
+from vimseo.problems.mock import X1_DEFAULT_VALUE
 from vimseo.tools.lib.space_builders import FromCenterAndCov
 from vimseo.tools.lib.space_builders import FromMinAndMax
 from vimseo.tools.lib.space_builders import FromModelCenterAndCov


### PR DESCRIPTION
Fixed test `tools/test_space_builders.py` that failed after refactoring of `mock` submodule.

Variable `X1_DEFAULT_VALUE` is now defined only once in submodule `mock`.

Closes #23 
Closes #24 