### PR TITLE
fix(tests): stop `test_none_field_roundtrip` writing `result.hdf5` to repo root

### DIFF
--- a/tests/tools/test_serialization.py
+++ b/tests/tools/test_serialization.py
@@ -60,7 +60,7 @@ def roundtrip(result: BaseResult, tmp_hdf5: str) -> BaseResult:
 class TestPrimitivesAndNone:
     def test_none_field_roundtrip(self, tmp_hdf5):
         result = BayesAnalysisResult(thin_number=None)
-        rt = roundtrip(result, "result.hdf5")
+        rt = roundtrip(result, tmp_hdf5)
         assert rt.thin_number is None
 
     def test_int_field_roundtrip(self, tmp_hdf5):


### PR DESCRIPTION
# Summary
`test_none_field_roundtrip` hardcoded "result.hdf5" instead of using the `tmp_hdf5` fixture, so the file landed at the repo root (CWD) instead of pytest's `tmp_path`, and was never cleaned up.
Pass `tmp_hdf5` through instead.
Closes #59 

# Test plan
 -  [x] `pytest tests/tools/test_serialization.py -q` — 32 passed
 -  [x] `git status` clean after run, no `result.hdf5` at repo root
