### PR TITLE
fix(doc): silence matplotlib + plotly popups and fix doc build crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ doc = [
     "black",
     "griffe-fieldz",
     "griffe-inherited-docstrings",
+    "ipython",
     "markdown-exec[ansi]",
     "mike",
     "mkdocs-bibtex",

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,6 +10,8 @@ annotated-types==0.7.0
     # via pydantic
 anyio==4.13.0
     # via starlette
+asttokens==3.0.2
+    # via stack-data
 attrs==26.1.0
     # via
     #   jsonschema
@@ -62,6 +64,8 @@ databricks-sdk==0.106.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
+decorator==5.3.1
+    # via ipython
 dill==0.4.1
     # via openturns
 dnspython==2.8.0
@@ -78,6 +82,8 @@ et-xmlfile==2.0.0
     # via openpyxl
 eval-type-backport==0.2.2
     # via vimseo (pyproject.toml)
+executing==2.2.1
+    # via stack-data
 fastapi==0.136.1
     # via mlflow-skinny
 fastjsonschema==2.20.0
@@ -154,8 +160,14 @@ importlib-metadata==8.7.1
     #   opentelemetry-api
 iniconfig==2.3.0
     # via pytest
+ipython==9.15.0
+    # via vimseo (pyproject.toml:doc)
+ipython-pygments-lexers==1.1.1
+    # via ipython
 itsdangerous==2.2.0
     # via flask
+jedi==0.20.0
+    # via ipython
 jinja2==3.1.4
     # via
     #   altair
@@ -211,6 +223,8 @@ matplotlib==3.9.2
     #   gemseo-vimseo
     #   mlflow
     #   seaborn
+matplotlib-inline==0.2.2
+    # via ipython
 mdurl==0.1.2
     # via markdown-it-py
 mergedeep==1.3.4
@@ -357,6 +371,8 @@ pandas==2.2.2
     #   seaborn
     #   statsmodels
     #   streamlit
+parso==0.8.7
+    # via jedi
 pathspec==1.1.1
     # via
     #   black
@@ -364,6 +380,8 @@ pathspec==1.1.1
     #   properdocs
 patsy==1.0.2
     # via statsmodels
+pexpect==4.9.0
+    # via ipython
 pillow==10.4.0
     # via
     #   gemseo-vimseo
@@ -381,6 +399,8 @@ plotly==5.24.0
     #   gemseo-vimseo
 pluggy==1.6.0
     # via pytest
+prompt-toolkit==3.0.52
+    # via ipython
 properdocs==1.6.7
     # via
     #   mkdocs-gen-files
@@ -394,7 +414,13 @@ protobuf==6.33.6
     #   opentelemetry-proto
     #   streamlit
 psutil==7.2.2
-    # via openturns
+    # via
+    #   ipython
+    #   openturns
+ptyprocess==0.7.0
+    # via pexpect
+pure-eval==0.2.3
+    # via stack-data
 pyarrow==21.0.0
     # via
     #   mlflow
@@ -430,6 +456,8 @@ pydoe3==1.0.4
     # via gemseo-vimseo
 pygments==2.20.0
     # via
+    #   ipython
+    #   ipython-pygments-lexers
     #   mkdocs-material
     #   pygments-ansi-color
     #   pytest
@@ -534,6 +562,8 @@ sqlalchemy==2.0.49
     #   mlflow
 sqlparse==0.5.5
     # via mlflow-skinny
+stack-data==0.6.3
+    # via ipython
 starlette==1.0.0
     # via fastapi
 statsmodels==0.14.5
@@ -566,7 +596,9 @@ tqdm==4.66.5
     #   mkdocs-gallery
 traitlets==5.15.0
     # via
+    #   ipython
     #   jupyter-core
+    #   matplotlib-inline
     #   nbformat
 typing-extensions==4.15.0
     # via
@@ -613,6 +645,8 @@ watchdog==6.0.0
     #   streamlit
 wcmatch==10.1
     # via mkdocs-include-markdown-plugin
+wcwidth==0.8.2
+    # via prompt-toolkit
 werkzeug==3.1.8
     # via
     #   flask

--- a/src/vimseo/core/base_discipline_model.py
+++ b/src/vimseo/core/base_discipline_model.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 
 
 class BaseDisciplineModel(IntegratedModel):
+    """An :class:`~.IntegratedModel` wrapping a single GEMSEO discipline."""
+
     _DISCIPLINE: ClassVar[Discipline | None] = None
     _EXPECTED_LOAD_CASE: ClassVar[str] = ""
 

--- a/src/vimseo/core/base_integrated_model.py
+++ b/src/vimseo/core/base_integrated_model.py
@@ -617,7 +617,7 @@ class IntegratedModel(GemseoDisciplineWrapper):
         Returns:
         """
         directory_path = (
-            self.archive_manager.job_directory
+            Path(self.archive_manager.job_directory)
             if directory_path == ""
             else Path(directory_path)
         )

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ description = build documentation
 basepython = python3.12
 deps = -r requirements/doc.txt
 set_env =
+    {[testenv]set_env}
     DOCSTRING_INHERITANCE_ENABLE = 1
 allowlist_externals =
     rm

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,10 @@ deps = -r requirements/doc.txt
 set_env =
     {[testenv]set_env}
     DOCSTRING_INHERITANCE_ENABLE = 1
+    # plotly's default renderer outside a notebook opens a browser tab
+    # (webbrowser.open) instead of rendering non-interactively. Use the
+    # renderer built for gallery-style doc builds instead.
+    PLOTLY_RENDERER = sphinx_gallery
 allowlist_externals =
     rm
     docs/modify_readme_image_url.py


### PR DESCRIPTION
Closes #61 

## Problem
`tox run -e doc` pops real GUI windows / browser tabs during the doc build, and the build itself crashes (`mkdocs serve` exits 1). Four independent causes.

## Cause 1: matplotlib GUI windows
`[testenv:doc]` in `tox.ini` defined its own `set_env` block, which in tox >=4 replaces (rather than merges with) `[testenv]`'s `set_env` — silently dropping `MPLBACKEND=AGG`. matplotlib then fell back to an interactive backend and every example's `show=True` call opened a window.

**Fix**: extend the base `set_env` explicitly (`{[testenv]set_env}`).

## Cause 2: plotly browser tabs
Examples rendered via gemseo's plotly-backed `DatasetPlot`/`Curve.plot` (`file_format="html"`) call `Figure.show()`, whose default renderer outside a notebook is `"browser"` → `webbrowser.open()` — unrelated to matplotlib/`MPLBACKEND`.

**Fix**: force plotly's `"sphinx_gallery"` renderer via `PLOTLY_RENDERER`, add `ipython` as a doc dependency (required by that renderer).

## Cause 3 (fatal — this is why the build exits 1): griffe/docstring_inheritance crash
`src/vimseo/core/base_discipline_model.py`'s `BaseDisciplineModel` class has no docstring. The `docstring_inheritance.griffe` mkdocstrings extension, synthesizing one from the runtime-inherited `__doc__`, walks up to the containing module looking for an already-resolved docstring parser to reuse — the module has none, so it raises `RuntimeError: Cannot find a docstring for the parent of the object Class('BaseDisciplineModel', 32, 45)`, which is fatal to the whole `mkdocs serve` process.

**Fix**: add a docstring to BaseDisciplineModel, so griffe's own parsed docstring is used directly and no parser lookup is needed for this class.

## Cause 4 (non-fatal, but breaks example output): `plot_results` `AttributeError`
`base_integrated_model.py`'s `plot_results` only wraps the explicit-`directory_path` branch in `Path(...)`; the default (`self.archive_manager.job_directory`, a plain `str` `""` until a job directory has actually been created) is left unwrapped, so `directory_path.exists()` raises `AttributeError: 'str' object has no attribute 'exists'` for every example that calls `plot_results(show=True)` without an explicit `directory_path` — most of `01_models` and others.

**Fix**: wrap that branch in `Path(...)` too (`Path("")` already resolves to `Path(".")`, matching the documented `"defaults to cwd"` behavior).

## Verification
- `tox config -e doc` — resolved `set_env` includes `MPLBACKEND=AGG` and `PLOTLY_RENDERER=sphinx_gallery`.
- `tox exec -e doc -- python -c "import matplotlib as mpl; print(mpl.get_backend())"` — prints `AGG`.
- `tox exec -e doc -- python -c "import plotly.graph_objects as go; go.Figure().show()"` — completes without opening a browser tab.
- Full `tox run -e doc` build log: no `ERROR`/traceback, no more `AttributeError: 'str' object has no attribute 'exists'` warnings for the `01_models` examples. `Documentation built in 161.24 seconds`, server started clean.